### PR TITLE
Fix failing master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 dnspython==2.1.0
+musicalbeeps==0.2.9
 numpy==1.21.3
 pip==21.3.1
 pymongo==3.12.1
 setuptools==58.3.0
+simpleaudio==1.0.4
 wheel==0.37.0


### PR DESCRIPTION
In the [last commit that was merged to master](https://github.com/edwardchang7/engg4000/commit/54b441488abfa38a9e61acf3bc1c98d15c9858e9), the musicalbeeps and the simpleaudio library was removed from requirements.txt. This made CircleCI tests fail on the master branch because frontend tests were using musicalbeeps (which uses simpleaudio) to execute some of its test cases.

This PR fixes the CircleCI tests that are failing in the master branch by simply adding the musicalbeeps and the simpleaudio libraries back into the requirements.txt.

NOTE: I did not revert the entire commit because the other code changes (for example, abc_tools.py) are needed.